### PR TITLE
Remove ASPNETCORE_ENVIRONMENT from web.config

### DIFF
--- a/src/Namster/web.config
+++ b/src/Namster/web.config
@@ -9,7 +9,7 @@
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" hostingModel="InProcess">
       <environmentVariables>
-        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+        
       </environmentVariables>
     </aspNetCore>
   </system.webServer>


### PR DESCRIPTION
Environment will be set by slot-specific app configuration